### PR TITLE
Crash Fix, Formatting Fixes, Renamings, Convention Corrections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation("curse.maven:simplyswords-659887:5255981")
 	modApi "dev.architectury:architectury-fabric:${rootProject.architectury_version}"
+	modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
+		exclude(group: "net.fabricmc.fabric-api")
+	}
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 	modCompileOnly("com.terraformersmc:modmenu:${rootProject.mod_menu_version}") { transitive false }

--- a/src/main/java/net/rosemarythmye/simplymore/Simplymore.java
+++ b/src/main/java/net/rosemarythmye/simplymore/Simplymore.java
@@ -1,7 +1,6 @@
 package net.rosemarythmye.simplymore;
 
 import net.fabricmc.api.ModInitializer;
-
 import net.rosemarythmye.simplymore.effect.ModEffects;
 import net.rosemarythmye.simplymore.item.ModItems;
 import org.slf4j.Logger;

--- a/src/main/java/net/rosemarythmye/simplymore/SimplymoreClient.java
+++ b/src/main/java/net/rosemarythmye/simplymore/SimplymoreClient.java
@@ -1,14 +1,8 @@
 package net.rosemarythmye.simplymore;
 
-import dev.architectury.event.events.client.ClientTooltipEvent;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
-import net.minecraft.client.render.entity.model.EntityModelLayer;
-import net.minecraft.util.Identifier;
-import net.sweenus.simplyswords.SimplySwords;
 
 @Environment(EnvType.CLIENT)
 public class SimplymoreClient implements ClientModInitializer {

--- a/src/main/java/net/rosemarythmye/simplymore/effect/LanceEffect.java
+++ b/src/main/java/net/rosemarythmye/simplymore/effect/LanceEffect.java
@@ -5,11 +5,10 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectCategory;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.Hand;
-import net.rosemarythmye.simplymore.item.itemclasses.normal.Lance;
-import net.rosemarythmye.simplymore.item.itemclasses.runics.RunicLance;
-import net.rosemarythmye.simplymore.item.itemclasses.uniques.Glimmerstep;
+import net.rosemarythmye.simplymore.item.normal.Lance;
+import net.rosemarythmye.simplymore.item.runics.RunicLance;
+import net.rosemarythmye.simplymore.item.uniques.Glimmerstep;
 
 public class LanceEffect extends StatusEffect {
     public LanceEffect(StatusEffectCategory category, int color) {
@@ -19,7 +18,7 @@ public class LanceEffect extends StatusEffect {
     @Override
     public void applyUpdateEffect(LivingEntity entity, int Amplifier) {
         if(!(entity.getMainHandStack().getItem() instanceof Lance || entity.getMainHandStack().getItem() instanceof RunicLance || entity.getMainHandStack().getItem() instanceof Glimmerstep) || !(entity.getVehicle() instanceof LivingEntity)) entity.removeStatusEffect(this);
-        if(!((PlayerEntity) entity).getStackInHand(Hand.OFF_HAND).getItem().getAttributeModifiers(EquipmentSlot.MAINHAND).get(EntityAttributes.GENERIC_ATTACK_DAMAGE).isEmpty()) entity.removeStatusEffect(this);
+        if(!entity.getStackInHand(Hand.OFF_HAND).getItem().getAttributeModifiers(EquipmentSlot.MAINHAND).get(EntityAttributes.GENERIC_ATTACK_DAMAGE).isEmpty()) entity.removeStatusEffect(this);
         super.applyUpdateEffect(entity, Amplifier);
     }
 

--- a/src/main/java/net/rosemarythmye/simplymore/effect/MimicryEffect.java
+++ b/src/main/java/net/rosemarythmye/simplymore/effect/MimicryEffect.java
@@ -5,7 +5,7 @@ import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectCategory;
-import net.rosemarythmye.simplymore.item.itemclasses.uniques.Mimicry;
+import net.rosemarythmye.simplymore.item.uniques.Mimicry;
 
 import java.util.UUID;
 

--- a/src/main/java/net/rosemarythmye/simplymore/effect/MoltenFlareEffect.java
+++ b/src/main/java/net/rosemarythmye/simplymore/effect/MoltenFlareEffect.java
@@ -7,7 +7,7 @@ import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectCategory;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.server.world.ServerWorld;
-import net.rosemarythmye.simplymore.item.itemclasses.uniques.MoltenFlare;
+import net.rosemarythmye.simplymore.item.uniques.MoltenFlare;
 
 import java.util.UUID;
 

--- a/src/main/java/net/rosemarythmye/simplymore/entity/Eruption.java
+++ b/src/main/java/net/rosemarythmye/simplymore/entity/Eruption.java
@@ -1,18 +1,11 @@
 package net.rosemarythmye.simplymore.entity;
 
-import com.google.common.collect.Maps;
 import net.minecraft.entity.AreaEffectCloudEntity;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.Ownable;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.particle.ParticleEffect;
-import net.minecraft.particle.ParticleType;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.world.World;
 
 import java.util.List;
-import java.util.Map;
 
 public class Eruption extends AreaEffectCloudEntity {
     public Eruption(World world, double x, double y, double z, int radius, LivingEntity owner) {

--- a/src/main/java/net/rosemarythmye/simplymore/item/ModItems.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/ModItems.java
@@ -1,8 +1,12 @@
 package net.rosemarythmye.simplymore.item;
 
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.item.ModelPredicateProviderRegistry;
-import net.minecraft.item.*;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroup;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ToolMaterials;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.text.Text;
@@ -10,17 +14,16 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.Rarity;
 import net.rosemarythmye.simplymore.Simplymore;
 import net.rosemarythmye.simplymore.effect.ModEffects;
-import net.rosemarythmye.simplymore.item.itemclasses.normal.Lance;
-import net.rosemarythmye.simplymore.item.itemclasses.normal.GrandSword;
-import net.rosemarythmye.simplymore.item.itemclasses.RuneCarver;
-import net.rosemarythmye.simplymore.item.itemclasses.normal.Sword;
-import net.rosemarythmye.simplymore.item.itemclasses.runics.RunicGrandSword;
-import net.rosemarythmye.simplymore.item.itemclasses.runics.RunicLance;
-import net.rosemarythmye.simplymore.item.itemclasses.uniques.*;
-import net.rosemarythmye.simplymore.item.itemclasses.uniques.joke.JesterPenetrate;
+import net.rosemarythmye.simplymore.item.normal.GrandSword;
+import net.rosemarythmye.simplymore.item.normal.Lance;
+import net.rosemarythmye.simplymore.item.normal.Sword;
+import net.rosemarythmye.simplymore.item.runics.RunicGrandSword;
+import net.rosemarythmye.simplymore.item.runics.RunicLance;
+import net.rosemarythmye.simplymore.item.uniques.*;
+import net.rosemarythmye.simplymore.item.uniques.joke.JesterPenetrate;
+import net.rosemarythmye.simplymore.util.SimplyMoreToolMaterial;
 import net.sweenus.simplyswords.config.Config;
 import net.sweenus.simplyswords.config.ConfigDefaultValues;
-import net.rosemarythmye.simplymore.util.ModToolMaterial;
 import net.sweenus.simplyswords.item.RunicSwordItem;
 import net.sweenus.simplyswords.registry.ItemsRegistry;
 
@@ -33,51 +36,319 @@ public class ModItems {
 
 
 
-    public static final Item IRON_GREAT_KATANA = registerItem("iron_great_katana",new Sword(ToolMaterials.IRON,(int)(iron_modifier+1),-2.6f,new Item.Settings(),"minecraft:iron_ingot"));
-    public static final Item GOLD_GREAT_KATANA = registerItem("gold_great_katana",new Sword(ToolMaterials.GOLD,(int)(gold_modifier+1),-2.6f,new Item.Settings(),"minecraft:gold_ingot"));
-    public static final Item DIAMOND_GREAT_KATANA = registerItem("diamond_great_katana",new Sword(ToolMaterials.DIAMOND,(int)(diamond_modifier+1),-2.6f,new Item.Settings(),"minecraft:diamond"));
-    public static final Item NETHERITE_GREAT_KATANA = registerItem("netherite_great_katana",new Sword(ToolMaterials.NETHERITE,(int)(netherite_modifier+1),-2.6f,new Item.Settings().fireproof(),"minecraft:netherite_ingot"));
-    public static final Item RUNIC_GREAT_KATANA = registerItem("runic_great_katana",new RunicSwordItem(ModToolMaterial.RUNIC,(int)(runic_modifier+1),-2.6f,new Item.Settings().fireproof()));
+    public static final Item IRON_GREAT_KATANA = registerItem(
+            "iron_great_katana",
+            new Sword(
+                    ToolMaterials.IRON,
+                    (int)(iron_modifier + 1),
+                    -2.6f,
+                    new Item.Settings(),
+                    "minecraft:iron_ingot"
+            )
+    );
+    public static final Item GOLD_GREAT_KATANA = registerItem(
+            "gold_great_katana",
+            new Sword(
+                    ToolMaterials.GOLD,
+                    (int)(gold_modifier + 1),
+                    -2.6f,
+                    new Item.Settings(),
+                    "minecraft:gold_ingot"
+            )
+    );
+    public static final Item DIAMOND_GREAT_KATANA = registerItem(
+            "diamond_great_katana",
+            new Sword(
+                    ToolMaterials.DIAMOND,
+                    (int)(diamond_modifier + 1),
+                    -2.6f,
+                    new Item.Settings(),
+                    "minecraft:diamond"
+            )
+    );
+    public static final Item NETHERITE_GREAT_KATANA = registerItem(
+            "netherite_great_katana",
+            new Sword(
+                    ToolMaterials.NETHERITE,
+                    (int)(netherite_modifier + 1),
+                    -2.6f,
+                    new Item.Settings()
+                            .fireproof(),
+                    "minecraft:netherite_ingot"
+            )
+    );
+    public static final Item RUNIC_GREAT_KATANA = registerItem(
+            "runic_great_katana",
+            new RunicSwordItem(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_RUNIC,
+                    (int)(runic_modifier + 1),
+                    -2.6f,
+                    new Item.Settings()
+                            .fireproof()
+            )
+    );
 
-    public static final Item IRON_GRANDSWORD = registerItem("iron_grandsword",new GrandSword(ToolMaterials.IRON,(int)(iron_modifier+6),-3.5f,new Item.Settings(),"minecraft:iron_ingot"));
-    public static final Item GOLD_GRANDSWORD = registerItem("gold_grandsword",new GrandSword(ToolMaterials.GOLD,(int)(gold_modifier+6),-3.5f,new Item.Settings(),"minecraft:gold_ingot"));
-    public static final Item DIAMOND_GRANDSWORD = registerItem("diamond_grandsword",new GrandSword(ToolMaterials.DIAMOND,(int)(diamond_modifier+6),-3.5f,new Item.Settings(),"minecraft:diamond"));
-    public static final Item NETHERITE_GRANDSWORD = registerItem("netherite_grandsword",new GrandSword(ToolMaterials.NETHERITE,(int)(netherite_modifier+6),-3.5f,new Item.Settings().fireproof(),"minecraft:netherite_ingot"));
-    public static final Item RUNIC_GRANDSWORD = registerItem("runic_grandsword",new RunicGrandSword(ModToolMaterial.RUNIC,(int)(runic_modifier+6),-3.5f,new Item.Settings().fireproof(),"minecraft:netherite_ingot"));
+    public static final Item IRON_GRANDSWORD = registerItem(
+            "iron_grandsword",
+            new GrandSword(
+                    ToolMaterials.IRON,
+                    (int)(iron_modifier+6),
+                    -3.5f,
+                    new Item.Settings(),
+                    "minecraft:iron_ingot"
+            )
+    );
+    public static final Item GOLD_GRANDSWORD = registerItem(
+            "gold_grandsword",
+            new GrandSword(
+                    ToolMaterials.GOLD,
+                    (int)(gold_modifier+6),
+                    -3.5f,
+                    new Item.Settings(),
+                    "minecraft:gold_ingot"
+            )
+    );
+    public static final Item DIAMOND_GRANDSWORD = registerItem(
+            "diamond_grandsword",
+            new GrandSword(
+                    ToolMaterials.DIAMOND,
+                    (int)(diamond_modifier+6),
+                    -3.5f,
+                    new Item.Settings(),
+                    "minecraft:diamond"
+            )
+    );
+    public static final Item NETHERITE_GRANDSWORD = registerItem(
+            "netherite_grandsword",
+            new GrandSword(
+                    ToolMaterials.NETHERITE,
+                    (int)(netherite_modifier+6),
+                    -3.5f,
+                    new Item.Settings()
+                            .fireproof(),
+                    "minecraft:netherite_ingot"
+            )
+    );
+    public static final Item RUNIC_GRANDSWORD = registerItem(
+            "runic_grandsword",
+            new RunicGrandSword(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_RUNIC,
+                    (int)(runic_modifier+6),
+                    -3.5f,
+                    new Item.Settings()
+                            .fireproof(),
+                    "minecraft:netherite_ingot"
+            )
+    );
+    
+    public static final Item IRON_BACKHAND_BLADE = registerItem(
+            "iron_backhand_blade", 
+            new Sword(
+                    ToolMaterials.IRON,
+                    (int)(iron_modifier - 2),
+                    -1.7f,
+                    new Item.Settings(),
+                    "minecraft:iron_ingot"
+            )
+    );
+    public static final Item GOLD_BACKHAND_BLADE = registerItem("gold_backhand_blade",
+            new Sword(
+                    ToolMaterials.GOLD,
+                    (int)(gold_modifier - 2),
+                    -1.7f,
+                    new Item.Settings(),
+                    "minecraft:gold_ingot"
+            )
+    );
+    public static final Item DIAMOND_BACKHAND_BLADE = registerItem(
+            "diamond_backhand_blade",
+            new Sword(
+                    ToolMaterials.DIAMOND,
+                    (int)(diamond_modifier - 2),
+                    -1.7f,
+                    new Item.Settings(),
+                    "minecraft:diamond"
+            )
+    );
+    public static final Item NETHERITE_BACKHAND_BLADE = registerItem(
+            "netherite_backhand_blade",
+            new Sword(
+                    ToolMaterials.NETHERITE,
+                    (int)(netherite_modifier - 2),
+                    -1.7f,
+                    new Item.Settings()
+                            .fireproof(),
+                    "minecraft:netherite_ingot"
+            )
+    );
+    public static final Item RUNIC_BACKHAND_BLADE = registerItem(
+            "runic_backhand_blade", 
+            new RunicSwordItem(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_RUNIC,
+                    (int)(runic_modifier - 2),
+                    -1.7f,
+                    new Item.Settings()
+                            .fireproof()
+            )
+    );
+
+    public static final Item IRON_LANCE = registerItem(
+            "iron_lance",
+            new Lance(
+                    ToolMaterials.IRON,
+                    (int)(iron_modifier+0),
+                    -3f,
+                    new Item.Settings(),
+                    "minecraft:iron_ingot"
+            )
+    );
+    public static final Item GOLD_LANCE = registerItem(
+            "gold_lance",
+            new Lance(
+                    ToolMaterials.GOLD,
+                    (int)(gold_modifier + 0),
+                    -3f,
+                    new Item.Settings(),
+                    "minecraft:gold_ingot"));
+    public static final Item DIAMOND_LANCE = registerItem(
+            "diamond_lance",
+            new Lance(
+                    ToolMaterials.DIAMOND,
+                    (int)(diamond_modifier + 0),
+                    -3f,
+                    new Item.Settings(),
+                    "minecraft:diamond"
+            )
+    );
+    public static final Item NETHERITE_LANCE = registerItem(
+            "netherite_lance",
+            new Lance(
+                    ToolMaterials.NETHERITE,
+                    (int)(netherite_modifier + 0),
+                    -3f,
+                    new Item.Settings()
+                            .fireproof(),
+                    "minecraft:netherite_ingot"
+            )
+    );
+    public static final Item RUNIC_LANCE = registerItem(
+            "runic_lance",
+            new RunicLance(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_RUNIC,
+                    (int)(runic_modifier + 0),
+                    -3f,
+                    new Item.Settings()
+                            .fireproof()
+            )
+    );
 
 
-    public static final Item IRON_BACKHAND_BLADE = registerItem("iron_backhand_blade",new Sword(ToolMaterials.IRON,(int)(iron_modifier-2),-1.7f,new Item.Settings(),"minecraft:iron_ingot"));
-    public static final Item GOLD_BACKHAND_BLADE = registerItem("gold_backhand_blade",new Sword(ToolMaterials.GOLD,(int)(gold_modifier-2),-1.7f,new Item.Settings(),"minecraft:gold_ingot"));
-    public static final Item DIAMOND_BACKHAND_BLADE = registerItem("diamond_backhand_blade",new Sword(ToolMaterials.DIAMOND,(int)(diamond_modifier-2),-1.7f,new Item.Settings(),"minecraft:diamond"));
-    public static final Item NETHERITE_BACKHAND_BLADE = registerItem("netherite_backhand_blade",new Sword(ToolMaterials.NETHERITE,(int)(netherite_modifier-2),-1.7f,new Item.Settings().fireproof(),"minecraft:netherite_ingot"));
-    public static final Item RUNIC_BACKHAND_BLADE = registerItem("runic_backhand_blade",new RunicSwordItem(((ToolMaterial) ModToolMaterial.RUNIC),(int)(runic_modifier-2),-1.7f,new Item.Settings().fireproof()));
+    public static final Item GREAT_SLITHER = registerItem(
+            "great_slither",
+            new GreatSlither(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_UNIQUE,
+                    5,
+                    -2.6f,
+                    new Item.Settings()
+                            .fireproof()
+                            .rarity(Rarity.EPIC)       
+            )
+    );
+    public static final Item MOLTEN_FLARE = registerItem(
+            "molten_flare",
+            new MoltenFlare(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_UNIQUE,
+                    7,
+                    -3.5f,
+                    new Item.Settings()
+                            .fireproof()
+                            .rarity(Rarity.EPIC)       
+            )
+    );
+    public static final Item GRANDFROST = registerItem(
+            "grandfrost",
+            new Grandfrost(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_UNIQUE,
+                    8,
+                    -3.5f,
+                    new Item.Settings()
+                            .fireproof()
+                            .rarity(Rarity.EPIC)       
+            )
+    );
+    public static final Item MIMICRY = registerItem(
+            "mimicry",
+            new Mimicry(
+                    SimplyMoreToolMaterial.SIMPLY_MORE_UNIQUE,
+                    2,
+                    -2f,
+                    new Item.Settings()
+                            .fireproof()
+                            .rarity(Rarity.EPIC)       
+            )
+    );
+    public static final Item GLIMMERSTEP = registerItem(
+            "glimmerstep",
+            new Glimmerstep(SimplyMoreToolMaterial.SIMPLY_MORE_UNIQUE,
+                    1,
+                    -3f,
+                    new Item.Settings()
+                            .fireproof()
+                            .rarity(Rarity.EPIC)
+            )
+    );
+    public static final Item THEBLOODHARVESTER = registerItem(
+            "the_blood_harvester",
+            new TheBloodHarvester(SimplyMoreToolMaterial.SIMPLY_MORE_UNIQUE,
+                    2,
+                    -2.4f,
+                    new Item.Settings()
+                            .fireproof()
+                            .rarity(Rarity.EPIC)
+            )
+    );
+    public static final Item JESTER_PENETRATE = registerItem(
+            "jester_penetrate",
+            new JesterPenetrate(SimplyMoreToolMaterial.SIMPLY_MORE_UNIQUE,
+                    0,
+                    -3f,
+                    new Item.Settings()
+                            .fireproof()
+                            .rarity(Rarity.EPIC)
+            )
+    );
 
-    public static final Item IRON_LANCE = registerItem("iron_lance",new Lance(ToolMaterials.IRON,(int)(iron_modifier+0),-3f,new Item.Settings(),"minecraft:iron_ingot"));
-    public static final Item GOLD_LANCE = registerItem("gold_lance",new Lance(ToolMaterials.GOLD,(int)(gold_modifier+0),-3f,new Item.Settings(),"minecraft:gold_ingot"));
-    public static final Item DIAMOND_LANCE = registerItem("diamond_lance",new Lance(ToolMaterials.DIAMOND,(int)(diamond_modifier+0),-3f,new Item.Settings(),"minecraft:diamond"));
-    public static final Item NETHERITE_LANCE = registerItem("netherite_lance",new Lance(ToolMaterials.NETHERITE,(int)(netherite_modifier+0),-3f,new Item.Settings().fireproof(),"minecraft:netherite_ingot"));
-    public static final Item RUNIC_LANCE = registerItem("runic_lance",new RunicLance(ModToolMaterial.RUNIC,(int)(runic_modifier+0),-3f,new Item.Settings().fireproof()));
 
-
-    public static final Item GREAT_SLITHER = registerItem("great_slither", new GreatSlither(ModToolMaterial.UNIQUE,5,-2.6f,new Item.Settings().fireproof().rarity(Rarity.EPIC)));
-    public static final Item MOLTEN_FLARE = registerItem("molten_flare", new MoltenFlare(ModToolMaterial.UNIQUE,7,-3.5f,new Item.Settings().fireproof().rarity(Rarity.EPIC)));
-    public static final Item GRANDFROST = registerItem("grandfrost", new Grandfrost(ModToolMaterial.UNIQUE,8,-3.5f,new Item.Settings().fireproof().rarity(Rarity.EPIC)));
-    public static final Item MIMICRY = registerItem("mimicry", new Mimicry(ModToolMaterial.UNIQUE,2,-2f,new Item.Settings().fireproof().rarity(Rarity.EPIC)));
-    public static final Item GLIMMERSTEP = registerItem("glimmerstep", new Glimmerstep(ModToolMaterial.UNIQUE,1,-3f,new Item.Settings().fireproof().rarity(Rarity.EPIC)));
-    public static final Item THEBLOODHARVESTER = registerItem("the_blood_harvester", new TheBloodHarvester(ModToolMaterial.UNIQUE,2,-2.4f,new Item.Settings().fireproof().rarity(Rarity.EPIC)));
-    public static final Item JESTER_PENETRATE = registerItem("jester_penetrate",new JesterPenetrate(ModToolMaterial.UNIQUE,0,-3f,new Item.Settings().fireproof().rarity(Rarity.EPIC)));
-
-
-    public static final Item RUNEFUSED_CARVER = registerItem("runefused_carver", new RuneCarver(new Item.Settings().maxCount(1).fireproof().rarity(Rarity.EPIC),"runic"));
-    public static final Item NETHERFUSED_CARVER = registerItem("netherfused_carver", new RuneCarver(new Item.Settings().maxCount(1).fireproof().rarity(Rarity.EPIC),"nether"));
+    public static final Item RUNEFUSED_CARVER = registerItem(
+            "runefused_carver",
+            new RuneCarver(
+                    new Item.Settings()
+                            .maxCount(1)
+                            .fireproof()
+                            .rarity(Rarity.EPIC),
+                    "runic"
+            )
+    );
+    public static final Item NETHERFUSED_CARVER = registerItem(
+            "netherfused_carver",
+            new RuneCarver(
+                    new Item.Settings()
+                            .maxCount(1)
+                            .fireproof()
+                            .rarity(Rarity.EPIC),
+                    "nether"
+            )
+    );
 
     public static Item registerItem (String name, Item item) {
         return Registry.register(Registries.ITEM, new Identifier(Simplymore.ID, name),item);
     }
     public static void registerModItems() {
-        Simplymore.LOGGER.info("Registering Items for " + Simplymore.ID);
-        Registry.register(Registries.ITEM_GROUP, Identifier.of(Simplymore.ID, "items"), ITEM_GROUP);
-        registerModelPredicates();
+        if (FabricLoader.getInstance().isModLoaded("simplyswords")) {
+            Simplymore.LOGGER.info("Registering Items for " + Simplymore.ID);
+            Registry.register(Registries.ITEM_GROUP, Identifier.of(Simplymore.ID, "items"), ITEM_GROUP);
+            registerModelPredicates();
+        }
     }
 
 

--- a/src/main/java/net/rosemarythmye/simplymore/item/RuneCarver.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/RuneCarver.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses;
+package net.rosemarythmye.simplymore.item;
 
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.item.Item;
@@ -32,13 +32,13 @@ public class RuneCarver extends Item {
         switch (type) {
             case "runic":
                 tooltip.add(Text.literal(""));
-                tooltip.add(Text.translatable("item.simplymore.runefused_carver.tooltip1").formatted(new Formatting[]{Formatting.GRAY, Formatting.ITALIC}));
-                tooltip.add(Text.translatable("item.simplymore.runefused_carver.tooltip2").formatted(new Formatting[]{Formatting.GRAY, Formatting.ITALIC}));
+                tooltip.add(Text.translatable("item.simplymore.runefused_carver.tooltip1").formatted(Formatting.GRAY, Formatting.ITALIC));
+                tooltip.add(Text.translatable("item.simplymore.runefused_carver.tooltip2").formatted(Formatting.GRAY, Formatting.ITALIC));
                 break;
             case "nether":
                 tooltip.add(Text.literal(""));
-                tooltip.add(Text.translatable("item.simplymore.netherfused_carver.tooltip1").formatted(new Formatting[]{Formatting.GRAY, Formatting.ITALIC}));
-                tooltip.add(Text.translatable("item.simplymore.netherfused_carver.tooltip2").formatted(new Formatting[]{Formatting.GRAY, Formatting.ITALIC}));
+                tooltip.add(Text.translatable("item.simplymore.netherfused_carver.tooltip1").formatted(Formatting.GRAY, Formatting.ITALIC));
+                tooltip.add(Text.translatable("item.simplymore.netherfused_carver.tooltip2").formatted(Formatting.GRAY, Formatting.ITALIC));
                 break;
         }
     }

--- a/src/main/java/net/rosemarythmye/simplymore/item/UniqueSword.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/UniqueSword.java
@@ -3,11 +3,8 @@
 // (powered by FernFlower decompiler)
 //
 
-package net.rosemarythmye.simplymore.item.itemclasses;
+package net.rosemarythmye.simplymore.item;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
@@ -27,6 +24,10 @@ import net.minecraft.world.World;
 import net.sweenus.simplyswords.api.SimplySwordsAPI;
 import net.sweenus.simplyswords.util.HelperMethods;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class UniqueSword extends SwordItem {
     String iRarity = "UNIQUE";
     String[] repairIngredient;
@@ -42,10 +43,10 @@ public class UniqueSword extends SwordItem {
     }
 
     public boolean canRepair(ItemStack stack, ItemStack ingredient) {
-        List<Item> potentialIngredients = new ArrayList(List.of());
-        Arrays.stream(this.repairIngredient).toList().forEach((repIngredient) -> {
-            potentialIngredients.add((Item) Registries.ITEM.get(new Identifier(repIngredient)));
-        });
+        List<Item> potentialIngredients = new ArrayList<>(List.of());
+        Arrays.stream(this.repairIngredient).toList().forEach(
+                (repIngredient) -> potentialIngredients.add(
+                        Registries.ITEM.get(new Identifier(repIngredient))));
         return potentialIngredients.contains(ingredient.getItem());
     }
 

--- a/src/main/java/net/rosemarythmye/simplymore/item/normal/GrandSword.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/normal/GrandSword.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.normal;
+package net.rosemarythmye.simplymore.item.normal;
 
 import net.minecraft.item.ToolMaterial;
 

--- a/src/main/java/net/rosemarythmye/simplymore/item/normal/Lance.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/normal/Lance.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.runics;
+package net.rosemarythmye.simplymore.item.normal;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
@@ -11,12 +11,10 @@ import net.minecraft.item.ToolMaterial;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import net.rosemarythmye.simplymore.effect.ModEffects;
-import net.sweenus.simplyswords.item.RunicSwordItem;
 
-public class RunicLance extends RunicSwordItem {
-    String[] repairIngredient;
+public class Lance extends Sword {
 
-    public RunicLance(ToolMaterial toolMaterial, int attackDamage, float attackSpeed, Settings settings, String... repairIngredient) {
+    public Lance(ToolMaterial toolMaterial, int attackDamage, float attackSpeed, Settings settings, String... repairIngredient) {
         super(toolMaterial, attackDamage, attackSpeed, settings);
 
         this.repairIngredient = repairIngredient;
@@ -24,7 +22,12 @@ public class RunicLance extends RunicSwordItem {
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
-        if(entity.getVehicle() instanceof LivingEntity && selected && ((PlayerEntity) entity).getStackInHand(Hand.OFF_HAND).getItem().getAttributeModifiers(EquipmentSlot.MAINHAND).get(EntityAttributes.GENERIC_ATTACK_DAMAGE).isEmpty()) ((PlayerEntity) entity).addStatusEffect(new StatusEffectInstance(ModEffects.LANCE,9999999,0));
+        if(entity.getVehicle() instanceof LivingEntity
+                && selected
+                && ((PlayerEntity) entity)
+                    .getStackInHand(Hand.OFF_HAND).getItem().getAttributeModifiers(EquipmentSlot.MAINHAND)
+                        .get(EntityAttributes.GENERIC_ATTACK_DAMAGE).isEmpty()) ((PlayerEntity) entity)
+                            .addStatusEffect(new StatusEffectInstance(ModEffects.LANCE,9999999,0));
         super.inventoryTick(stack, world, entity, slot, selected);
     }
 }

--- a/src/main/java/net/rosemarythmye/simplymore/item/normal/Sword.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/normal/Sword.java
@@ -1,14 +1,17 @@
-package net.rosemarythmye.simplymore.item.itemclasses.normal;
+package net.rosemarythmye.simplymore.item.normal;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.SwordItem;
+import net.minecraft.item.ToolMaterial;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+import net.sweenus.simplyswords.util.HelperMethods;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.item.*;
-import net.minecraft.registry.Registries;
-import net.minecraft.util.Identifier;
-import net.sweenus.simplyswords.util.HelperMethods;
 public class Sword extends SwordItem {
     String[] repairIngredient;
 
@@ -19,10 +22,10 @@ public class Sword extends SwordItem {
     }
 
     public boolean canRepair(ItemStack stack, ItemStack ingredient) {
-        List<Item> potentialIngredients = new ArrayList(List.of());
-        Arrays.stream(this.repairIngredient).toList().forEach((repIngredient) -> {
-            potentialIngredients.add((Item) Registries.ITEM.get(new Identifier(repIngredient)));
-        });
+        List<Item> potentialIngredients = new ArrayList<>(List.of());
+        Arrays.stream(this.repairIngredient).toList().forEach(
+                (repIngredient) -> potentialIngredients.add(
+                        Registries.ITEM.get(new Identifier(repIngredient))));
         return potentialIngredients.contains(ingredient.getItem());
     }
 

--- a/src/main/java/net/rosemarythmye/simplymore/item/runics/RunicGrandSword.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/runics/RunicGrandSword.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.runics;
+package net.rosemarythmye.simplymore.item.runics;
 
 import net.minecraft.item.ToolMaterial;
 import net.sweenus.simplyswords.item.RunicSwordItem;

--- a/src/main/java/net/rosemarythmye/simplymore/item/runics/RunicLance.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/runics/RunicLance.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.normal;
+package net.rosemarythmye.simplymore.item.runics;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EquipmentSlot;
@@ -11,10 +11,12 @@ import net.minecraft.item.ToolMaterial;
 import net.minecraft.util.Hand;
 import net.minecraft.world.World;
 import net.rosemarythmye.simplymore.effect.ModEffects;
+import net.sweenus.simplyswords.item.RunicSwordItem;
 
-public class Lance extends Sword {
+public class RunicLance extends RunicSwordItem {
+    String[] repairIngredient;
 
-    public Lance(ToolMaterial toolMaterial, int attackDamage, float attackSpeed, Settings settings, String... repairIngredient) {
+    public RunicLance(ToolMaterial toolMaterial, int attackDamage, float attackSpeed, Settings settings, String... repairIngredient) {
         super(toolMaterial, attackDamage, attackSpeed, settings);
 
         this.repairIngredient = repairIngredient;
@@ -22,7 +24,12 @@ public class Lance extends Sword {
 
     @Override
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
-        if(entity.getVehicle() instanceof LivingEntity && selected && ((PlayerEntity) entity).getStackInHand(Hand.OFF_HAND).getItem().getAttributeModifiers(EquipmentSlot.MAINHAND).get(EntityAttributes.GENERIC_ATTACK_DAMAGE).isEmpty()) ((PlayerEntity) entity).addStatusEffect(new StatusEffectInstance(ModEffects.LANCE,9999999,0));
+        if(entity.getVehicle() instanceof LivingEntity
+                && selected
+                && ((PlayerEntity) entity)
+                .getStackInHand(Hand.OFF_HAND).getItem().getAttributeModifiers(EquipmentSlot.MAINHAND)
+                    .get(EntityAttributes.GENERIC_ATTACK_DAMAGE).isEmpty()) ((PlayerEntity) entity)
+                        .addStatusEffect(new StatusEffectInstance(ModEffects.LANCE,9999999,0));
         super.inventoryTick(stack, world, entity, slot, selected);
     }
 }

--- a/src/main/java/net/rosemarythmye/simplymore/item/uniques/Glimmerstep.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/uniques/Glimmerstep.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.uniques;
+package net.rosemarythmye.simplymore.item.uniques;
 
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
@@ -18,13 +18,11 @@ import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.UseAction;
 import net.minecraft.util.math.Position;
 import net.minecraft.world.World;
-import net.rosemarythmye.simplymore.item.itemclasses.UniqueSword;
+import net.rosemarythmye.simplymore.item.UniqueSword;
 import net.sweenus.simplyswords.registry.SoundRegistry;
 import net.sweenus.simplyswords.util.HelperMethods;
 
 import java.util.List;
-
-import static java.lang.Math.max;
 
 public class Glimmerstep extends UniqueSword {
     int skillCooldown = 1200;
@@ -62,7 +60,7 @@ public class Glimmerstep extends UniqueSword {
 
 
     public void usageTick(World world, LivingEntity user, ItemStack stack, int remainingUseTicks) {
-        if (!user.getWorld().isClient && user instanceof PlayerEntity player) {
+        if (!user.getWorld().isClient && user instanceof PlayerEntity) {
             ServerWorld serverWorld = ((ServerWorld) world);
             if(remainingUseTicks==this.getMaxUseTime(null)-1) serverWorld.playSound(null,user.getBlockPos(),SoundEvents.BLOCK_BEACON_ACTIVATE,user.getSoundCategory(),1.0f,0.8f);
             serverWorld.spawnParticles(ParticleTypes.GLOW,user.getX(),user.getY()+1,user.getZ(), ((int) Math.floor((double) (60 - remainingUseTicks) / 2)),0.2,0.4,0.2,0.5);

--- a/src/main/java/net/rosemarythmye/simplymore/item/uniques/Grandfrost.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/uniques/Grandfrost.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.uniques;
+package net.rosemarythmye.simplymore.item.uniques;
 
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
@@ -17,7 +17,7 @@ import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.math.Box;
 import net.minecraft.world.World;
 import net.rosemarythmye.simplymore.effect.ModEffects;
-import net.rosemarythmye.simplymore.item.itemclasses.UniqueSword;
+import net.rosemarythmye.simplymore.item.UniqueSword;
 import net.sweenus.simplyswords.registry.SoundRegistry;
 import net.sweenus.simplyswords.util.HelperMethods;
 
@@ -63,7 +63,7 @@ public class Grandfrost extends UniqueSword {
             if(use) {
                 user.getItemCooldownManager().set(this.getDefaultStack().getItem(), skillCooldown);
                 if(!user.getWorld().isClient()) ((ServerWorld) user.getWorld()).spawnParticles(ParticleTypes.SNOWFLAKE,user.getX(),user.getY()+3,user.getZ(),1000,3,0,3,0.25);
-                user.getWorld().playSound((PlayerEntity)null, user.getBlockPos(), SoundRegistry.ELEMENTAL_SWORD_ICE_ATTACK_03.get(), user.getSoundCategory(), 2F, 0.3F);
+                user.getWorld().playSound(null, user.getBlockPos(), SoundRegistry.ELEMENTAL_SWORD_ICE_ATTACK_03.get(), user.getSoundCategory(), 2F, 0.3F);
 
             }
         }

--- a/src/main/java/net/rosemarythmye/simplymore/item/uniques/GreatSlither.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/uniques/GreatSlither.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.uniques;
+package net.rosemarythmye.simplymore.item.uniques;
 
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
@@ -15,7 +15,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 import net.rosemarythmye.simplymore.entity.GreatSlitherFang;
-import net.rosemarythmye.simplymore.item.itemclasses.UniqueSword;
+import net.rosemarythmye.simplymore.item.UniqueSword;
 import net.sweenus.simplyswords.util.HelperMethods;
 import org.joml.Vector2d;
 

--- a/src/main/java/net/rosemarythmye/simplymore/item/uniques/Mimicry.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/uniques/Mimicry.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.uniques;
+package net.rosemarythmye.simplymore.item.uniques;
 
 import com.google.common.collect.Multimap;
 import net.minecraft.client.item.TooltipContext;
@@ -22,7 +22,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 import net.rosemarythmye.simplymore.effect.ModEffects;
-import net.rosemarythmye.simplymore.item.itemclasses.UniqueSword;
+import net.rosemarythmye.simplymore.item.UniqueSword;
 import net.sweenus.simplyswords.registry.SoundRegistry;
 import net.sweenus.simplyswords.util.HelperMethods;
 
@@ -78,15 +78,18 @@ public class Mimicry extends UniqueSword {
 
             Object form = stack.getOrCreateNbt().get("simplymore:form");
             if (form==null) super.postHit(stack, target, attacker);
-            form = form.toString();
+            if (form != null) {
+                form = form.toString();
 
-            StatusEffect statusEffect = null;
-            if (this.hitCount % 5 == 0 && form.toString().equals("\"purity\"")) {
-                statusEffect = PositiveEffects[attacker.getRandom().nextInt(PositiveEffects.length)];
-                attacker.addStatusEffect(new StatusEffectInstance(statusEffect,200,1));
-            } else if (this.hitCount % 4 == 0 && form.toString().equals("\"twisted\"")) {
-                statusEffect = NegativeEffects[attacker.getRandom().nextInt(NegativeEffects.length)];
-                target.addStatusEffect(new StatusEffectInstance(statusEffect,200,1));
+
+                StatusEffect statusEffect;
+                if (this.hitCount % 5 == 0 && form.toString().equals("\"purity\"")) {
+                    statusEffect = PositiveEffects[attacker.getRandom().nextInt(PositiveEffects.length)];
+                    attacker.addStatusEffect(new StatusEffectInstance(statusEffect, 200, 1));
+                } else if (this.hitCount % 4 == 0 && form.toString().equals("\"twisted\"")) {
+                    statusEffect = NegativeEffects[attacker.getRandom().nextInt(NegativeEffects.length)];
+                    target.addStatusEffect(new StatusEffectInstance(statusEffect, 200, 1));
+                }
             }
         }
         return super.postHit(stack, target, attacker);
@@ -101,7 +104,7 @@ public class Mimicry extends UniqueSword {
             if (form==null) return TypedActionResult.fail(user.getStackInHand(hand));
             form = form.toString();
             ((ServerWorld) user.getWorld()).spawnParticles(ParticleTypes.ELECTRIC_SPARK,user.getX(),user.getY()+0.5,user.getZ(),50,0.5,0.5,0.5,0.25);
-            user.getWorld().playSound((PlayerEntity)null, user.getBlockPos(), SoundRegistry.MAGIC_BOW_CHARGE_SHORT_VERSION.get(), user.getSoundCategory(), 2F, 1F);
+            user.getWorld().playSound(null, user.getBlockPos(), SoundRegistry.MAGIC_BOW_CHARGE_SHORT_VERSION.get(), user.getSoundCategory(), 2F, 1F);
 
             if (form.equals("\"twisted\"")) user.getStackInHand(hand).getOrCreateNbt().putString("simplymore:form", "purity");
             else user.getStackInHand(hand).getOrCreateNbt().putString("simplymore:form", "twisted");
@@ -141,7 +144,7 @@ public class Mimicry extends UniqueSword {
         form = stack.getOrCreateNbt().get("simplymore:form");
 
         if (selected && entity instanceof PlayerEntity) {
-            if(form.toString().equals("\"twisted\"")) ((PlayerEntity) entity).addStatusEffect(new StatusEffectInstance(ModEffects.MIMICRY,9999999,0,true,false,false));
+            if(form != null && form.toString().equals("\"twisted\"")) ((PlayerEntity) entity).addStatusEffect(new StatusEffectInstance(ModEffects.MIMICRY,9999999,0,true,false,false));
             else ((PlayerEntity) entity).removeStatusEffect(ModEffects.MIMICRY);
         }
 

--- a/src/main/java/net/rosemarythmye/simplymore/item/uniques/MoltenFlare.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/uniques/MoltenFlare.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.uniques;
+package net.rosemarythmye.simplymore.item.uniques;
 
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
@@ -16,7 +16,7 @@ import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 import net.rosemarythmye.simplymore.effect.ModEffects;
 import net.rosemarythmye.simplymore.entity.Eruption;
-import net.rosemarythmye.simplymore.item.itemclasses.UniqueSword;
+import net.rosemarythmye.simplymore.item.UniqueSword;
 import net.sweenus.simplyswords.registry.SoundRegistry;
 import net.sweenus.simplyswords.util.HelperMethods;
 
@@ -58,7 +58,7 @@ public class MoltenFlare extends UniqueSword {
     private void eruption(int radius,LivingEntity target,LivingEntity attacker) {
         ((ServerWorld) attacker.getWorld()).spawnParticles(ParticleTypes.LAVA, attacker.getX(), attacker.getY(), attacker.getZ(), 100, 0, 0, 0, 0);
         attacker.getWorld().spawnEntity(new Eruption(attacker.getWorld(),attacker.getX(),attacker.getY(),attacker.getZ(),radius,attacker));
-        attacker.getWorld().playSound((PlayerEntity)null, attacker.getBlockPos(), SoundRegistry.SPELL_FIRE.get(), attacker.getSoundCategory(), 2F, 0.3F);
+        attacker.getWorld().playSound(null, attacker.getBlockPos(), SoundRegistry.SPELL_FIRE.get(), attacker.getSoundCategory(), 2F, 0.3F);
     }
 
     public void appendTooltip(ItemStack itemStack, World world, List<Text> tooltip, TooltipContext tooltipContext) {

--- a/src/main/java/net/rosemarythmye/simplymore/item/uniques/TheBloodHarvester.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/uniques/TheBloodHarvester.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.uniques;
+package net.rosemarythmye.simplymore.item.uniques;
 
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
@@ -17,7 +17,7 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.world.World;
 import net.rosemarythmye.simplymore.effect.ModEffects;
-import net.rosemarythmye.simplymore.item.itemclasses.UniqueSword;
+import net.rosemarythmye.simplymore.item.UniqueSword;
 import net.sweenus.simplyswords.registry.SoundRegistry;
 import net.sweenus.simplyswords.util.HelperMethods;
 
@@ -50,7 +50,7 @@ public class TheBloodHarvester extends UniqueSword {
             user.addStatusEffect(new StatusEffectInstance(ModEffects.HARVEST, 300, 0));
             user.getItemCooldownManager().set(this.getDefaultStack().getItem(), skillCooldown);
             ((ServerWorld) user.getWorld()).spawnParticles(ParticleTypes.CRIMSON_SPORE, user.getX(), user.getY() + 0.5, user.getZ(), 500, 0.5, 0.5, 0.5, 0.25);
-            user.getWorld().playSound((PlayerEntity) null, user.getBlockPos(), SoundRegistry.MAGIC_SWORD_ATTACK_WITH_BLOOD_04.get(), user.getSoundCategory(), 2F, 0F);
+            user.getWorld().playSound(null, user.getBlockPos(), SoundRegistry.MAGIC_SWORD_ATTACK_WITH_BLOOD_04.get(), user.getSoundCategory(), 2F, 0F);
         }
         return super.use(world, user, hand);
     }

--- a/src/main/java/net/rosemarythmye/simplymore/item/uniques/joke/JesterPenetrate.java
+++ b/src/main/java/net/rosemarythmye/simplymore/item/uniques/joke/JesterPenetrate.java
@@ -1,4 +1,4 @@
-package net.rosemarythmye.simplymore.item.itemclasses.uniques.joke;
+package net.rosemarythmye.simplymore.item.uniques.joke;
 
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.Entity;
@@ -10,7 +10,7 @@ import net.minecraft.item.ToolMaterial;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.world.World;
-import net.rosemarythmye.simplymore.item.itemclasses.normal.Lance;
+import net.rosemarythmye.simplymore.item.normal.Lance;
 import net.sweenus.simplyswords.util.HelperMethods;
 
 import java.util.List;

--- a/src/main/java/net/rosemarythmye/simplymore/mixin/LivingEntityMixin.java
+++ b/src/main/java/net/rosemarythmye/simplymore/mixin/LivingEntityMixin.java
@@ -4,10 +4,10 @@ import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
-import net.rosemarythmye.simplymore.item.itemclasses.normal.GrandSword;
-import net.rosemarythmye.simplymore.item.itemclasses.runics.RunicGrandSword;
-import net.rosemarythmye.simplymore.item.itemclasses.uniques.Grandfrost;
-import net.rosemarythmye.simplymore.item.itemclasses.uniques.MoltenFlare;
+import net.rosemarythmye.simplymore.item.normal.GrandSword;
+import net.rosemarythmye.simplymore.item.runics.RunicGrandSword;
+import net.rosemarythmye.simplymore.item.uniques.Grandfrost;
+import net.rosemarythmye.simplymore.item.uniques.MoltenFlare;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 

--- a/src/main/java/net/rosemarythmye/simplymore/util/SimplyMoreToolMaterial.java
+++ b/src/main/java/net/rosemarythmye/simplymore/util/SimplyMoreToolMaterial.java
@@ -1,35 +1,29 @@
 package net.rosemarythmye.simplymore.util;
 
-import com.google.common.base.Suppliers;
-import net.minecraft.item.Item;
 import net.minecraft.item.Items;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.Registries;
-import net.sweenus.simplyswords.registry.ItemsRegistry;
+import net.minecraft.util.Identifier;
 
-import java.util.function.Supplier;
-
-public enum ModToolMaterial implements ToolMaterial {
-    UNIQUE(4, 3270, 15.0F, 5.0F, 30, new Item[]{(Item) Items.AIR}),
-    RUNIC(4, 2031, 9.0F, 5.0F, 25, new Item[]{Items.NETHERITE_INGOT});
+public enum SimplyMoreToolMaterial implements ToolMaterial {
+    SIMPLY_MORE_UNIQUE(4, 3270, 15.0F, 5.0F, 30, "simplyswords:runic_tablet"),
+    SIMPLY_MORE_RUNIC(4, 2031, 9.0F, 5.0F, 25, "minecraft:netherite_ingot");
 
     private final int miningLevel;
     private final int itemDurability;
     private final float miningSpeed;
     private final float attackDamage;
     private final int enchantability;
-    private final Supplier<Ingredient> repairIngredient;
+    private final String repairIngredient;
 
-    private ModToolMaterial(int miningLevel, int itemDurability, float miningSpeed, float attackDamage, int enchantability, Item... repairIngredient) {
+    SimplyMoreToolMaterial(int miningLevel, int itemDurability, float miningSpeed, float attackDamage, int enchantability, String repairIngredient) {
         this.miningLevel = miningLevel;
         this.itemDurability = itemDurability;
         this.miningSpeed = miningSpeed;
         this.attackDamage = attackDamage;
         this.enchantability = enchantability;
-        this.repairIngredient = Suppliers.memoize(() -> {
-            return Ingredient.ofItems(repairIngredient);
-        });
+        this.repairIngredient = repairIngredient;
     }
 
     public int getDurability() {
@@ -53,7 +47,6 @@ public enum ModToolMaterial implements ToolMaterial {
     }
 
     public Ingredient getRepairIngredient() {
-        return (Ingredient)this.repairIngredient.get();
+        return Ingredient.ofItems(Registries.ITEM.getOrEmpty(new Identifier(repairIngredient)).orElse(Items.DIAMOND));
     }
-
 }


### PR DESCRIPTION
 - Fixed crash when `SimplyMore` loaded before `SimplySwords`. This was accomplished by changing the repair ingredient from an `Item` to a parsed `String`
 - Added `cloth-config` to `build.gradle` to prevent crashes for those who clone the repository
 - Started with numerous formatting fixes including, but not limited to:
   - Missing spaces after commas
   - Missing spaces in logical arguments (x==y vs x == y)
   - Compressed text changed to more readable text
 - Renamed `ModToolMaterial` to `SimplyMoreToolMaterial` in order to assist with future debugging and potential end-user crashes
 - Removed `itemclasses` directory and moved the files that were inside that directory directly into the `item` directory to follow convention
 - Removed redundant casts in various places
 - Removed raw uses of parameterised classes
 - Converted statement lambdas to expression lambdas, where possible
 - Prevented several potential `Null Pointer Exceptions` due to unsafe usage of potentially null fields and parameters
 - Optimised Imports